### PR TITLE
Fix font change after running help

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -52,6 +52,7 @@ export default function help(charm) {
   for (let arg of args) {
     printArg(arg, charm);
   }
+  .display('reset')
 };
 
 function printArg({arg, desc = false, def = false, alias = false}, charm) {


### PR DESCRIPTION
Currently, when you run batch-transcode with --help, it currently never resets the display so the font color stays gray. I think this one-liner hopefully fixes this?